### PR TITLE
修复LXC环境下GPT-SoVITS语音发送问题

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -289,7 +289,13 @@ class UnifiedTTSAction(BaseAction):
                         with open(audio_path, "wb") as f:
                             f.write(audio_data)
 
-                        await self.send_custom(message_type="voiceurl", content=audio_path)
+                        # 将音频文件转换为base64编码以供发送
+                        import base64
+                        with open(audio_path, "rb") as audio_file:
+                            audio_bytes = audio_file.read()
+                            audio_base64 = base64.b64encode(audio_bytes).decode('utf-8')
+
+                        await self.send_custom(message_type="voice", content=audio_base64)
                         logger.info(f"{self.log_prefix} GPT-SoVITS语音发送成功")
                         return True, f"成功发送GPT-SoVITS语音 (风格: {voice_style})"
                     else:
@@ -602,7 +608,13 @@ class UnifiedTTSCommand(BaseCommand):
                         with open(audio_path, "wb") as f:
                             f.write(audio_data)
 
-                        await self.send_custom(message_type="voiceurl", content=audio_path)
+                        # 将音频文件转换为base64编码以供发送
+                        import base64
+                        with open(audio_path, "rb") as audio_file:
+                            audio_bytes = audio_file.read()
+                            audio_base64 = base64.b64encode(audio_bytes).decode('utf-8')
+
+                        await self.send_custom(message_type="voice", content=audio_base64)
                         return True, f"成功发送GPT-SoVITS语音 (风格: {voice_style})"
                     else:
                         return False, f"GPT-SoVITS API失败: {response.status}"


### PR DESCRIPTION
- 将音频文件路径改为base64编码发送
- 修复Action和Command两个组件的GPT-SoVITS方法

## 问题描述
在LXC容器环境中，TTS语音插件使用GPT-SoVITS后端时无法正确发送语音，错误信息为"识别URL失败"。

## 原因分析
插件直接使用本地文件路径发送语音消息，但在LXC容器环境下，NapCat无法正确识别本地文件路径。

## 解决方案
将生成的音频文件转换为base64编码后发送，而不是直接发送文件路径。修复了`UnifiedTTSAction._execute_gpt_sovits`和`UnifiedTTSCommand._execute_gpt_sovits_command`两个方法。

## 测试
已在LXC容器环境中测试，修复后GPT-SoVITS语音可以正常发送。

以下是人写的
插件有点问题，我不懂怎么解决，于是求助qwen-coder，以上都是在AI的指导下完成的